### PR TITLE
Actor redrawing rework

### DIFF
--- a/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
@@ -5,19 +5,30 @@ namespace Anamnesis.Actor.Refresh;
 
 using Anamnesis.Memory;
 using Anamnesis.Services;
+using RemoteController.Interop.Delegates;
+using Serilog;
+using System;
+using System.Threading;
 using System.Threading.Tasks;
-using static Anamnesis.Memory.GameObjectMemory;
+
+public enum RedrawStage
+{
+	Before,
+	After,
+}
 
 public class AnamnesisActorRefresher : IActorRefresher
 {
+	public RedrawService RedrawService { get; } = new RedrawService();
+
 	public bool CanRefresh(ActorMemory actor)
 	{
 		if (PoseService.Instance.IsEnabled)
 			return false;
 
 		// Ana can't refresh gpose actors
-		if (actor.IsGPoseActor)
-			return false;
+		//if (actor.IsGPoseActor)
+		//	return false;
 
 		// Ana can't refresh world frozen actors
 		if (PoseService.Instance.FreezeWorldPosition)
@@ -28,21 +39,196 @@ public class AnamnesisActorRefresher : IActorRefresher
 
 	public async Task RefreshActor(ActorMemory actor)
 	{
-		if (SettingsService.Current.EnableNpcHack && actor.ObjectKind == ActorTypes.Player)
+		//if (SettingsService.Current.EnableNpcHack && actor.ObjectKind == ActorTypes.Player)
+		//{
+		//	actor.ObjectKind = ActorTypes.EventNpc;
+		//	actor.RenderMode = RenderModes.Unload;
+		//	await Task.Delay(75);
+		//	actor.RenderMode = RenderModes.Draw;
+		//	await Task.Delay(75);
+		//	actor.ObjectKind = ActorTypes.Player;
+		//	actor.RenderMode = RenderModes.Draw;
+		//}
+		//else
+		//{
+		//	actor.RenderMode = RenderModes.Unload;
+		//	await Task.Delay(75);
+		//	actor.RenderMode = RenderModes.Draw;
+		//}
+
+		var handle = ActorService.Instance.ObjectTable.Get<GameObjectMemory>(actor.Address);
+		if (handle == null || !handle.IsValid)
+			return;
+
+		await this.RedrawService.Redraw(handle);
+	}
+}
+
+public class RedrawService
+{
+	private static HookHandle? s_enableDrawHook = null;
+	private static HookHandle? s_disableDrawHook = null;
+	private static HookHandle? s_isReadyToDrawHook = null;
+
+	public RedrawService()
+	{
+		Log.Debug("RedrawService: Registering hooks...");
+		s_enableDrawHook = ControllerService.Instance.RegisterWrapper<GameObject.EnableDraw>();
+		Log.Debug("RedrawService: Registered s_enableDrawHook: {Hook}", s_enableDrawHook);
+		s_disableDrawHook = ControllerService.Instance.RegisterWrapper<GameObject.DisableDraw>();
+		Log.Debug("RedrawService: Registered s_disableDrawHook: {Hook}", s_disableDrawHook);
+		s_isReadyToDrawHook = ControllerService.Instance.RegisterWrapper<GameObject.IsReadyToDraw>();
+		Log.Debug("RedrawService: Registered s_isReadyToDrawHook: {Hook}", s_isReadyToDrawHook);
+	}
+
+	public delegate void RedrawEvent(ObjectHandle<GameObjectMemory> obj, RedrawStage stage);
+	public event RedrawEvent? OnRedraw;
+
+	public static async Task DrawWhenReady(int objectIndex)
+	{
+		if (ControllerService.Instance == null || ControllerService.Instance.Framework?.Active != true)
+			return;
+
+		IntPtr currentPtr = ActorService.Instance.ObjectTable.GetAddress(objectIndex);
+		using var obj = new ObjectHandle<GameObjectMemory>(currentPtr, ActorService.Instance.ObjectTable);
+
+		await ControllerService.Instance.Framework.RunOnTickUntilAsync(
+			() => IsReadyToDraw(obj),
+			deferTicks: 5,
+			timeoutTicks: 100,
+			() => EnableDraw(objectIndex));
+	}
+
+	public static bool IsReadyToDraw(ObjectHandle<GameObjectMemory> obj)
+	{
+		if (!obj.IsValid || s_isReadyToDrawHook == null)
+			return false;
+		bool? result = null;
+		try
 		{
-			actor.ObjectKind = ActorTypes.EventNpc;
-			actor.RenderMode = RenderModes.Unload;
-			await Task.Delay(75);
-			actor.RenderMode = RenderModes.Draw;
-			await Task.Delay(75);
-			actor.ObjectKind = ActorTypes.Player;
-			actor.RenderMode = RenderModes.Draw;
+			result = ControllerService.Instance.InvokeHook<bool>(s_isReadyToDrawHook, mode: RemoteController.Interop.DispatchMode.FrameworkTick, args: obj.Address);
+			if (result == null)
+			{
+				Log.Warning("Object is ready to draw invocation returned null");
+			}
 		}
-		else
+		catch
 		{
-			actor.RenderMode = RenderModes.Unload;
-			await Task.Delay(75);
-			actor.RenderMode = RenderModes.Draw;
+			Log.Verbose("Failed to invoke 'IsReadyToDraw' hook.");
+		}
+
+		return result ?? false;
+	}
+
+	public static bool DisableDraw(int objectIndex)
+	{
+		IntPtr currentPtr = ActorService.Instance.ObjectTable.GetAddress(objectIndex);
+		using var obj = new ObjectHandle<GameObjectMemory>(currentPtr, ActorService.Instance.ObjectTable);
+
+		if (!obj.IsValid || s_disableDrawHook == null)
+			return false;
+
+		long? result = null;
+		try
+		{
+			result = ControllerService.Instance.InvokeHook<long>(s_disableDrawHook, args: obj.Address, mode: RemoteController.Interop.DispatchMode.FrameworkTick, timeoutMs: 1000);
+			if (result == null)
+			{
+				Log.Warning("Object disable draw invocation returned null");
+			}
+		}
+		catch
+		{
+			Log.Verbose("Failed to invoke 'DisableDraw' hook.");
+		}
+
+		return result.HasValue && result.Value != 0;
+	}
+
+	public static bool EnableDraw(int objectIndex)
+	{
+		IntPtr currentPtr = ActorService.Instance.ObjectTable.GetAddress(objectIndex);
+		using var obj = new ObjectHandle<GameObjectMemory>(currentPtr, ActorService.Instance.ObjectTable);
+
+		if (!obj.IsValid || s_enableDrawHook == null)
+			return false;
+
+		byte? result = null;
+		try
+		{
+			result = ControllerService.Instance.InvokeHook<byte>(s_enableDrawHook, args: obj.Address, mode: RemoteController.Interop.DispatchMode.FrameworkTick, timeoutMs: 1000);
+			if (result == null)
+			{
+				Log.Warning("Object enable draw invocation returned null");
+			}
+		}
+		catch
+		{
+			Log.Verbose("Failed to invoke 'EnableDraw' hook.");
+		}
+
+		return result.HasValue && result.Value != 0;
+	}
+
+	public static async Task WaitForDrawing(int objectIndex)
+	{
+		if (ControllerService.Instance == null || ControllerService.Instance.Framework?.Active != true)
+			return;
+
+		IntPtr currentPtr = ActorService.Instance.ObjectTable.GetAddress(objectIndex);
+		using var obj = new ObjectHandle<GameObjectMemory>(currentPtr, ActorService.Instance.ObjectTable);
+
+		await ControllerService.Instance.Framework.RunOnTickUntilAsync(
+			() => obj.Do(o => o.ModelObject?.IsVisible == true) == true,
+			deferTicks: 5,
+			timeoutTicks: 100);
+	}
+
+	public async Task Redraw(ObjectHandle<GameObjectMemory> obj)
+	{
+		string name = obj.DoRef(a => a.DisplayName) ?? "Unknown";
+		Log.Debug($"Redrawing game object \"{name}\": 0x{obj.Address:X}");
+
+		ActorService.Instance.ObjectTable.Refresh();
+		int objectIndex = ActorService.Instance.ObjectTable.GetIndexOf(obj.Address);
+		if (objectIndex == -1)
+		{
+			Log.Error("Could not find the object index for the actor \"{name}\"");
+			return;
+		}
+
+		try
+		{
+			bool disableResult = DisableDraw(objectIndex);
+			if (!disableResult)
+			{
+				// TODO: Perhaps instead of skipping the redraw, retry?
+				// TOOD: To the same with EnableDraw below.
+				Log.Warning($"Failed to disable draw for object \"{name}\". Skipping redraw.");
+				return;
+			}
+
+			this.OnRedraw?.Invoke(obj, RedrawStage.Before);
+
+			try
+			{
+				await DrawWhenReady(objectIndex);
+			}
+			catch (OperationCanceledException)
+			{
+				Log.Warning("DrawWhenReady timed out. Forcing EnableDraw.");
+				ControllerService.Instance.Framework.RunAfterTicks(3, () => EnableDraw(objectIndex));
+				return;
+			}
+
+			await WaitForDrawing(objectIndex);
+
+			this.OnRedraw?.Invoke(obj, RedrawStage.After);
+			Log.Debug($"Redrew object \"{name}\".");
+		}
+		catch (Exception ex)
+		{
+			Log.Error(ex, $"Failed to redraw object \"{name}\".");
 		}
 	}
 }

--- a/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
@@ -8,7 +8,6 @@ using Anamnesis.Services;
 using RemoteController.Interop.Delegates;
 using Serilog;
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 
 public enum RedrawStage
@@ -26,10 +25,6 @@ public class AnamnesisActorRefresher : IActorRefresher
 		if (PoseService.Instance.IsEnabled)
 			return false;
 
-		// Ana can't refresh gpose actors
-		//if (actor.IsGPoseActor)
-		//	return false;
-
 		// Ana can't refresh world frozen actors
 		if (PoseService.Instance.FreezeWorldPosition)
 			return false;
@@ -39,28 +34,20 @@ public class AnamnesisActorRefresher : IActorRefresher
 
 	public async Task RefreshActor(ActorMemory actor)
 	{
-		//if (SettingsService.Current.EnableNpcHack && actor.ObjectKind == ActorTypes.Player)
-		//{
-		//	actor.ObjectKind = ActorTypes.EventNpc;
-		//	actor.RenderMode = RenderModes.Unload;
-		//	await Task.Delay(75);
-		//	actor.RenderMode = RenderModes.Draw;
-		//	await Task.Delay(75);
-		//	actor.ObjectKind = ActorTypes.Player;
-		//	actor.RenderMode = RenderModes.Draw;
-		//}
-		//else
-		//{
-		//	actor.RenderMode = RenderModes.Unload;
-		//	await Task.Delay(75);
-		//	actor.RenderMode = RenderModes.Draw;
-		//}
-
 		var handle = ActorService.Instance.ObjectTable.Get<GameObjectMemory>(actor.Address);
-		if (handle == null || !handle.IsValid)
+		if (handle == null)
 			return;
 
-		await this.RedrawService.Redraw(handle);
+		if (SettingsService.Current.EnableNpcHack && actor.ObjectKind == ActorTypes.Player)
+		{
+			actor.ObjectKind = ActorTypes.EventNpc;
+			await this.RedrawService.Redraw(handle);
+			actor.ObjectKind = ActorTypes.Player;
+		}
+		else
+		{
+			await this.RedrawService.Redraw(handle);
+		}
 	}
 }
 
@@ -68,167 +55,48 @@ public class RedrawService
 {
 	private static HookHandle? s_enableDrawHook = null;
 	private static HookHandle? s_disableDrawHook = null;
-	private static HookHandle? s_isReadyToDrawHook = null;
 
 	public RedrawService()
 	{
-		Log.Debug("RedrawService: Registering hooks...");
-		s_enableDrawHook = ControllerService.Instance.RegisterWrapper<GameObject.EnableDraw>();
-		Log.Debug("RedrawService: Registered s_enableDrawHook: {Hook}", s_enableDrawHook);
-		s_disableDrawHook = ControllerService.Instance.RegisterWrapper<GameObject.DisableDraw>();
-		Log.Debug("RedrawService: Registered s_disableDrawHook: {Hook}", s_disableDrawHook);
-		s_isReadyToDrawHook = ControllerService.Instance.RegisterWrapper<GameObject.IsReadyToDraw>();
-		Log.Debug("RedrawService: Registered s_isReadyToDrawHook: {Hook}", s_isReadyToDrawHook);
+		s_enableDrawHook = ControllerService.Instance.RegisterWrapper<Character.EnableDraw>();
+		s_disableDrawHook = ControllerService.Instance.RegisterWrapper<Character.DisableDraw>();
 	}
 
 	public delegate void RedrawEvent(ObjectHandle<GameObjectMemory> obj, RedrawStage stage);
 	public event RedrawEvent? OnRedraw;
 
-	public static async Task DrawWhenReady(int objectIndex)
-	{
-		if (ControllerService.Instance == null || ControllerService.Instance.Framework?.Active != true)
-			return;
-
-		IntPtr currentPtr = ActorService.Instance.ObjectTable.GetAddress(objectIndex);
-		using var obj = new ObjectHandle<GameObjectMemory>(currentPtr, ActorService.Instance.ObjectTable);
-
-		await ControllerService.Instance.Framework.RunOnTickUntilAsync(
-			() => IsReadyToDraw(obj),
-			deferTicks: 5,
-			timeoutTicks: 100,
-			() => EnableDraw(objectIndex));
-	}
-
-	public static bool IsReadyToDraw(ObjectHandle<GameObjectMemory> obj)
-	{
-		if (!obj.IsValid || s_isReadyToDrawHook == null)
-			return false;
-		bool? result = null;
-		try
-		{
-			result = ControllerService.Instance.InvokeHook<bool>(s_isReadyToDrawHook, mode: RemoteController.Interop.DispatchMode.FrameworkTick, args: obj.Address);
-			if (result == null)
-			{
-				Log.Warning("Object is ready to draw invocation returned null");
-			}
-		}
-		catch
-		{
-			Log.Verbose("Failed to invoke 'IsReadyToDraw' hook.");
-		}
-
-		return result ?? false;
-	}
-
-	public static bool DisableDraw(int objectIndex)
-	{
-		IntPtr currentPtr = ActorService.Instance.ObjectTable.GetAddress(objectIndex);
-		using var obj = new ObjectHandle<GameObjectMemory>(currentPtr, ActorService.Instance.ObjectTable);
-
-		if (!obj.IsValid || s_disableDrawHook == null)
-			return false;
-
-		long? result = null;
-		try
-		{
-			result = ControllerService.Instance.InvokeHook<long>(s_disableDrawHook, args: obj.Address, mode: RemoteController.Interop.DispatchMode.FrameworkTick, timeoutMs: 1000);
-			if (result == null)
-			{
-				Log.Warning("Object disable draw invocation returned null");
-			}
-		}
-		catch
-		{
-			Log.Verbose("Failed to invoke 'DisableDraw' hook.");
-		}
-
-		return result.HasValue && result.Value != 0;
-	}
-
-	public static bool EnableDraw(int objectIndex)
-	{
-		IntPtr currentPtr = ActorService.Instance.ObjectTable.GetAddress(objectIndex);
-		using var obj = new ObjectHandle<GameObjectMemory>(currentPtr, ActorService.Instance.ObjectTable);
-
-		if (!obj.IsValid || s_enableDrawHook == null)
-			return false;
-
-		byte? result = null;
-		try
-		{
-			result = ControllerService.Instance.InvokeHook<byte>(s_enableDrawHook, args: obj.Address, mode: RemoteController.Interop.DispatchMode.FrameworkTick, timeoutMs: 1000);
-			if (result == null)
-			{
-				Log.Warning("Object enable draw invocation returned null");
-			}
-		}
-		catch
-		{
-			Log.Verbose("Failed to invoke 'EnableDraw' hook.");
-		}
-
-		return result.HasValue && result.Value != 0;
-	}
-
-	public static async Task WaitForDrawing(int objectIndex)
-	{
-		if (ControllerService.Instance == null || ControllerService.Instance.Framework?.Active != true)
-			return;
-
-		IntPtr currentPtr = ActorService.Instance.ObjectTable.GetAddress(objectIndex);
-		using var obj = new ObjectHandle<GameObjectMemory>(currentPtr, ActorService.Instance.ObjectTable);
-
-		await ControllerService.Instance.Framework.RunOnTickUntilAsync(
-			() => obj.Do(o => o.ModelObject?.IsVisible == true) == true,
-			deferTicks: 5,
-			timeoutTicks: 100);
-	}
-
 	public async Task Redraw(ObjectHandle<GameObjectMemory> obj)
 	{
-		string name = obj.DoRef(a => a.DisplayName) ?? "Unknown";
-		Log.Debug($"Redrawing game object \"{name}\": 0x{obj.Address:X}");
+		if (!obj.IsValid)
+			return;
 
-		ActorService.Instance.ObjectTable.Refresh();
+		string name = obj.DoRef(a => a.DisplayName) ?? "Unknown";
+
 		int objectIndex = ActorService.Instance.ObjectTable.GetIndexOf(obj.Address);
 		if (objectIndex == -1)
 		{
-			Log.Error("Could not find the object index for the actor \"{name}\"");
+			Log.Error($"Could not find the object index for the actor \"{name}\"[Index: {objectIndex}, Address: 0x{obj.Address:X}].");
 			return;
 		}
 
 		try
 		{
-			bool disableResult = DisableDraw(objectIndex);
-			if (!disableResult)
-			{
-				// TODO: Perhaps instead of skipping the redraw, retry?
-				// TOOD: To the same with EnableDraw below.
-				Log.Warning($"Failed to disable draw for object \"{name}\". Skipping redraw.");
-				return;
-			}
-
 			this.OnRedraw?.Invoke(obj, RedrawStage.Before);
 
-			try
+			using (var batch = ControllerService.Instance.CreateBatchInvoke())
 			{
-				await DrawWhenReady(objectIndex);
-			}
-			catch (OperationCanceledException)
-			{
-				Log.Warning("DrawWhenReady timed out. Forcing EnableDraw.");
-				ControllerService.Instance.Framework.RunAfterTicks(3, () => EnableDraw(objectIndex));
-				return;
-			}
+				batch.Mode = RemoteController.Interop.DispatchMode.FrameworkTick;
 
-			await WaitForDrawing(objectIndex);
+				IntPtr objPtr = ActorService.Instance.ObjectTable.GetAddress(objectIndex);
+				batch.AddCall<long>(s_disableDrawHook!, args: objPtr);
+				batch.AddCall<byte>(s_enableDrawHook!, args: objPtr);
+			}
 
 			this.OnRedraw?.Invoke(obj, RedrawStage.After);
-			Log.Debug($"Redrew object \"{name}\".");
 		}
 		catch (Exception ex)
 		{
-			Log.Error(ex, $"Failed to redraw object \"{name}\".");
+			Log.Error(ex, $"Failed to redraw object \"{name}\"[Index: {objectIndex}, Address: 0x{obj.Address:X}].");
 		}
 	}
 }

--- a/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
@@ -39,7 +39,7 @@ public class AnamnesisActorRefresher : IActorRefresher
 			return;
 
 		var isInGpose = GposeService.IsInGpose() ?? GposeService.Instance.IsGpose;
-		if (SettingsService.Current.EnableNpcHack && isInGpose && actor.ObjectKind == ActorTypes.Player)
+		if (SettingsService.Current.EnableNpcHack && !isInGpose && actor.ObjectKind == ActorTypes.Player)
 		{
 			// NOTE: This workaround is necessary only when we're in the overworld
 			actor.ObjectKind = ActorTypes.EventNpc;

--- a/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
+++ b/Anamnesis/Actor/Refresh/AnamnesisActorRefresher.cs
@@ -38,8 +38,10 @@ public class AnamnesisActorRefresher : IActorRefresher
 		if (handle == null)
 			return;
 
-		if (SettingsService.Current.EnableNpcHack && actor.ObjectKind == ActorTypes.Player)
+		var isInGpose = GposeService.IsInGpose() ?? GposeService.Instance.IsGpose;
+		if (SettingsService.Current.EnableNpcHack && isInGpose && actor.ObjectKind == ActorTypes.Player)
 		{
+			// NOTE: This workaround is necessary only when we're in the overworld
 			actor.ObjectKind = ActorTypes.EventNpc;
 			await this.RedrawService.Redraw(handle);
 			actor.ObjectKind = ActorTypes.Player;

--- a/Anamnesis/Anamnesis.csproj
+++ b/Anamnesis/Anamnesis.csproj
@@ -27,6 +27,8 @@
     <NeutralLanguage>en</NeutralLanguage>
     <TrimmerRootAssembly>Serilog; RemoteController</TrimmerRootAssembly>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
   </PropertyGroup>
   <ItemGroup>
     <RemoteControllerSources

--- a/Anamnesis/Core/Memory/NativeFunctions.cs
+++ b/Anamnesis/Core/Memory/NativeFunctions.cs
@@ -377,61 +377,6 @@ internal static partial class NativeFunctions
 	}
 
 	/// <summary>
-	/// Flags for use with the <see cref="MoveFileEx"/> Windows API function.
-	/// </summary>
-	[Flags]
-	public enum MoveFileFlag : uint
-	{
-		/// <summary>
-		/// If a file named lpNewFileName exists, the function replaces its contents with the contents of the
-		/// lpExistingFileName file, provided that security requirements regarding access control lists (ACLs) are
-		/// met.
-		///
-		/// If lpNewFileName names an existing directory, an error is reported.
-		/// </summary>
-		MOVEFILE_REPLACE_EXISTING = 0x00000001,
-
-		/// <summary>
-		/// If the file is to be moved to a different volume, the function simulates the move by using the CopyFile
-		/// and DeleteFile functions. If the file is successfully copied to a different volume and the original file
-		/// is unable to be deleted, the function succeeds leaving the source file intact.
-		///
-		/// This value cannot be used with MOVEFILE_DELAY_UNTIL_REBOOT.
-		/// </summary>
-		MOVEFILE_COPY_ALLOWED = 0x00000002,
-
-		/// <summary>
-		/// The system does not move the file until the operating system is restarted. The system moves the file
-		/// immediately after AUTOCHK is executed, but before creating any paging files. Consequently, this parameter
-		/// enables the function to delete paging files from previous startups. This value can be used only if the
-		/// process is in the context of a user who belongs to the administrators group or the LocalSystem account.
-		///
-		/// This value cannot be used with MOVEFILE_COPY_ALLOWED.
-		/// </summary>
-		MOVEFILE_DELAY_UNTIL_REBOOT = 0x00000004,
-
-		/// <summary>
-		/// The function does not return until the file is actually moved on the disk. Setting this value guarantees
-		/// that a move performed as a copy and delete operation is flushed to disk before the function returns.
-		/// The flush occurs at the end of the copy operation.
-		///
-		/// This value has no effect if MOVEFILE_DELAY_UNTIL_REBOOT is set.
-		/// </summary>
-		MOVEFILE_WRITE_THROUGH = 0x00000008,
-
-		/// <summary>
-		/// Reserved for future use.
-		/// </summary>
-		MOVEFILE_CREATE_HARDLINK = 0x00000010,
-
-		/// <summary>
-		/// The function fails if the source file is a link source, but the file cannot be tracked after the move.
-		/// This situation can occur if the destination is a volume formatted with the FAT file system.
-		/// </summary>
-		MOVEFILE_FAIL_IF_NOT_TRACKABLE = 0x00000020,
-	}
-
-	/// <summary>
 	/// Contains values that specify security impersonation levels. Security impersonation levels govern the
 	/// degree to which a server process can act on behalf of a client process.
 	/// </summary>
@@ -1206,53 +1151,6 @@ internal static partial class NativeFunctions
 	[LibraryImport("kernel32.dll", SetLastError = true)]
 	[return: MarshalAs(UnmanagedType.Bool)]
 	public static partial bool GetExitCodeThread(IntPtr hThread, out uint lpExitCode);
-
-	/// <summary>
-	/// Moves an existing file or directory, including its children, with various move options.
-	///
-	/// The MoveFileWithProgress function is equivalent to the MoveFileEx function, except that
-	/// MoveFileWithProgress allows you to provide a callback function that receives progress notifications.
-	///
-	/// To perform this operation as a transacted operation, use the MoveFileTransacted function.
-	/// </summary>
-	/// <remarks>
-	/// If the dwFlags parameter specifies MOVEFILE_DELAY_UNTIL_REBOOT, MoveFileEx fails if it cannot access
-	/// the registry. The function stores the locations of the files to be renamed at restart in the following
-	/// registry value: HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations
-	/// For more information, see: https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw.
-	/// </remarks>
-	/// <param name="lpExistingFileName">
-	/// The current name of the file or directory on the local computer.
-	///
-	/// If dwFlags specifies MOVEFILE_DELAY_UNTIL_REBOOT, the file cannot exist on a remote share, because delayed
-	/// operations are performed before the network is available.
-	///
-	/// By default, the name is limited to MAX_PATH characters. To extend this limit to 32,767 wide characters,
-	/// prepend "\\?\" to the path.
-	/// </param>
-	/// <param name="lpNewFileName">
-	/// The new name of the file or directory on the local computer. When moving a file, the destination can be
-	/// on a different file system or volume.If the destination is on another drive, you must set the
-	/// MOVEFILE_COPY_ALLOWED flag in dwFlags.
-	///
-	/// When moving a directory, the destination must be on the same drive.
-	///
-	/// If dwFlags specifies MOVEFILE_DELAY_UNTIL_REBOOT and lpNewFileName is NULL, MoveFileEx registers the
-	/// lpExistingFileName file to be deleted when the system restarts.If lpExistingFileName refers to a directory,
-	/// the system removes the directory at restart only if the directory is empty.
-	/// </param>
-	/// <param name="dwFlags">
-	/// This parameter can be one or more of the values defined in <see cref="MoveFileFlag"/>
-	/// </param>
-	/// <returns>
-	/// If the function succeeds, the return value is nonzero.
-	///
-	/// If the function fails, the return value is zero(0). To get extended error information,
-	/// call GetLastError.
-	/// </returns>
-	[LibraryImport("kernel32.dll", EntryPoint = "MoveFileExW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
-	[return: MarshalAs(UnmanagedType.Bool)]
-	public static partial bool MoveFileEx(string lpExistingFileName, string? lpNewFileName, uint dwFlags);
 
 	/// <summary>
 	/// Retrieves a handle to the foreground window (the window with which the user is currently working).

--- a/Anamnesis/Core/Skeleton.cs
+++ b/Anamnesis/Core/Skeleton.cs
@@ -20,8 +20,6 @@ using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 
-// TODO: Add fallback to the old method of adding bones if the new method fails.
-
 /// <summary>
 /// Represents a skeleton of hierarchically-parented bones of an actor that can be posed.
 /// </summary>

--- a/Anamnesis/Core/Skeleton.cs
+++ b/Anamnesis/Core/Skeleton.cs
@@ -203,7 +203,7 @@ public class Skeleton : INotifyPropertyChanged
 	/// <summary>Reads the transforms of all bones in the skeleton.</summary>
 	public void ReadTransforms()
 	{
-		if (this.Bones == null || (this.Actor?.Do(a => a.ModelObject?.Skeleton == null) ?? true) || !GposeService.IsInGpose())
+		if (this.Bones == null || (this.Actor?.Do(a => a.ModelObject?.Skeleton == null) ?? true) || !GposeService.Instance.IsGpose)
 			return;
 
 		// If history is restoring, wait until it's done.

--- a/Anamnesis/Core/WorkQueue.cs
+++ b/Anamnesis/Core/WorkQueue.cs
@@ -48,6 +48,11 @@ public class WorkQueue
 	}
 
 	/// <summary>
+	/// Gets a value indicating whether the queue is empty.
+	/// </summary>
+	public bool IsEmpty => !this.reader.CanPeek || !this.reader.TryPeek(out _);
+
+	/// <summary>
 	/// Enqueue a work item asynchronously.
 	/// </summary>
 	/// <param name="action">

--- a/Anamnesis/Files/CharacterFile.cs
+++ b/Anamnesis/Files/CharacterFile.cs
@@ -456,7 +456,7 @@ public class CharacterFile : JsonFileBase
 
 			// Setting customize values will reset the extended appearance, which me must read.
 			actor.PauseSynchronization = false;
-			actor.Synchronize();
+			actor.Synchronize(exclGroups: TargetService.ExcludeSkeletonGroup);
 			actor.PauseSynchronization = true;
 		}
 

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -34,6 +34,7 @@ public class ActorMemory : GameObjectMemory, IDisposable
 	private readonly FuncQueue backupQueue;
 
 	private int isRefreshing = 0;
+	private bool needsRefresh = false;
 
 	public ActorMemory()
 	{
@@ -253,12 +254,13 @@ public class ActorMemory : GameObjectMemory, IDisposable
 	public async Task Refresh()
 	{
 		if (this.IsRefreshing)
+		{
+			Log.Debug("Refresh requested while busy. Marking as pending.");
+			this.needsRefresh = true;
 			return;
+		}
 
-		if (!this.CanRefresh)
-			return;
-
-		if (this.Address == IntPtr.Zero)
+		if (!this.CanRefresh || this.Address == IntPtr.Zero)
 			return;
 
 		try
@@ -267,14 +269,19 @@ public class ActorMemory : GameObjectMemory, IDisposable
 
 			this.IsRefreshing = true;
 
-			if (await RefreshActor(this))
+			do
 			{
-				Log.Information($"Completed actor refresh for actor address: {this.Address}");
+				this.needsRefresh = false;
+				if (await RefreshActor(this))
+				{
+					Log.Information($"Completed actor refresh cycle for: {this.Address}");
+				}
+				else
+				{
+					Log.Information($"Could not refresh actor: {this.Address}");
+				}
 			}
-			else
-			{
-				Log.Information($"Could not refresh actor: {this.Address}");
-			}
+			while (this.needsRefresh);
 		}
 		catch (Exception ex)
 		{

--- a/Anamnesis/Memory/ActorMemory.cs
+++ b/Anamnesis/Memory/ActorMemory.cs
@@ -255,7 +255,7 @@ public class ActorMemory : GameObjectMemory, IDisposable
 	{
 		if (this.IsRefreshing)
 		{
-			Log.Debug("Refresh requested while busy. Marking as pending.");
+			Log.Verbose("Refresh requested while busy. Marking as pending.");
 			this.needsRefresh = true;
 			return;
 		}
@@ -265,7 +265,7 @@ public class ActorMemory : GameObjectMemory, IDisposable
 
 		try
 		{
-			Log.Information($"Attempting actor refresh for actor address: {this.Address}");
+			Log.Information($"Attempting actor refresh for actor address: 0x{this.Address:X}");
 
 			this.IsRefreshing = true;
 
@@ -274,18 +274,18 @@ public class ActorMemory : GameObjectMemory, IDisposable
 				this.needsRefresh = false;
 				if (await RefreshActor(this))
 				{
-					Log.Information($"Completed actor refresh cycle for: {this.Address}");
+					Log.Information($"Completed actor refresh cycle for: 0x{this.Address:X}");
 				}
 				else
 				{
-					Log.Information($"Could not refresh actor: {this.Address}");
+					Log.Information($"Could not refresh actor: 0x{this.Address:X}");
 				}
 			}
 			while (this.needsRefresh);
 		}
 		catch (Exception ex)
 		{
-			Log.Error(ex, $"Error refreshing actor: {this.Address}");
+			Log.Error(ex, $"Error refreshing actor: 0x{this.Address:X}");
 		}
 		finally
 		{

--- a/Anamnesis/ServiceManager.cs
+++ b/Anamnesis/ServiceManager.cs
@@ -129,6 +129,12 @@ public class ServiceManager
 
 		foreach (IService service in reversedServices)
 		{
+			if (!service.IsInitialized || !service.IsAlive)
+			{
+				Log.Verbose($"Skipping shutdown of service: {service.GetType().Name} as it is not initialized or already shut down.");
+				continue;
+			}
+
 			try
 			{
 				// If this throws an exception we should keep trying to shut down the rest

--- a/Anamnesis/Services/ActorService.cs
+++ b/Anamnesis/Services/ActorService.cs
@@ -165,6 +165,27 @@ public class ObjectTable : INotifyPropertyChanged, IDisposable
 	}
 
 	/// <summary>
+	/// Gets the address of the object at the specified index.
+	/// </summary>
+	/// <param name="index">The index in the object table.</param>
+	/// <returns>The address of the object, or IntPtr.Zero if empty/out of bounds.</returns>
+	public IntPtr GetAddress(int index)
+	{
+		if (index < 0 || index >= OBJECT_TABLE_SIZE)
+			return IntPtr.Zero;
+
+		this.tableLock.EnterReadLock();
+		try
+		{
+			return this.objTable[index];
+		}
+		finally
+		{
+			this.tableLock.ExitReadLock();
+		}
+	}
+
+	/// <summary>
 	/// Checks if the object table contains the provided object pointer.
 	/// </summary>
 	/// <param name="ptr">The object pointer to check for.</param>

--- a/Anamnesis/Services/AddressService.cs
+++ b/Anamnesis/Services/AddressService.cs
@@ -166,7 +166,7 @@ public class AddressService : ServiceBase<AddressService>
 			GetAddressFromSignature("TargetSystem", "48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 3B C6 0F 95 C0", 3, (p) => { TargetSystem = p; }),
 			GetAddressFromSignature("Camera", "48 8D 35 ?? ?? ?? ?? 48 8B 09", 0, (p) => { s_cameraManager = p; }),
 			GetAddressFromTextSignature("TimeAsm", "48 89 87 ?? ?? ?? ?? 48 69 C0", (p) => TimeAsm = p),
-			GetAddressFromSignature("Framework", "48 8B 1D ?? ?? ?? ?? 8B 7C 24", 3, (p) => Framework = MemoryService.ReadPtr(p)),
+			GetAddressFromSignature("Framework", "48 8B 1D ?? ?? ?? ?? 8B 7C 24", 0, (p) => Framework = MemoryService.ReadPtr(p)),
 			GetAddressFromTextSignature("SkeletonFreezePhysics (1/2/3)", "0F 11 00 41 0F 10 4C 24 ?? 0F 11 48 10 41 0F 10 44 24 ?? 0F 11 40 20 48 8B 46 28", (p) =>
 				{
 					SkeletonFreezePhysics2 = p;

--- a/Anamnesis/Services/ControllerService.cs
+++ b/Anamnesis/Services/ControllerService.cs
@@ -872,7 +872,7 @@ public class ControllerService : ServiceBase<ControllerService>
 				targetAddress = MemoryService.Scanner.ScanText(attr.Signature);
 			}
 		}
-		catch (KeyNotFoundException ex)
+		catch (Exception ex)
 		{
 			Log.Error(ex, $"Failed to resolve signature for: {delegateKey}");
 			return null;
@@ -1301,7 +1301,7 @@ public class ControllerService : ServiceBase<ControllerService>
 			// Resolve function address at vtable location
 			targetAddress = MemoryService.ReadPtr(targetAddress);
 		}
-		catch (KeyNotFoundException ex)
+		catch (Exception ex)
 		{
 			Log.Error(ex, $"Failed to resolve signature for: {delegateKey}");
 			return;

--- a/Anamnesis/Services/ControllerService.cs
+++ b/Anamnesis/Services/ControllerService.cs
@@ -1175,7 +1175,7 @@ public class ControllerService : ServiceBase<ControllerService>
 			return;
 		}
 
-		if (this.pendingByeMessage.TryGetResult(out _))
+		if (msgId == HookMessageId.GOODBYE_MESSAGE_ID)
 		{
 			this.pendingByeMessage.SetResult(true);
 			return;
@@ -1196,7 +1196,7 @@ public class ControllerService : ServiceBase<ControllerService>
 			return;
 		}
 
-		if (this.pendingByeMessage.TryGetResult(out _))
+		if (msgId == HookMessageId.GOODBYE_MESSAGE_ID)
 		{
 			this.pendingByeMessage.SetResult(false);
 			return;
@@ -1415,7 +1415,7 @@ public class ControllerService : ServiceBase<ControllerService>
 			return;
 
 		this.pendingByeMessage.Reset();
-		var header = new MessageHeader(type: PayloadType.Bye);
+		var header = new MessageHeader(HookMessageId.GOODBYE_MESSAGE_ID, type: PayloadType.Bye);
 		this.outgoingEndpoint.Write(header, IPC_TIMEOUT_MS);
 
 		if (this.pendingByeMessage.Wait(IPC_TIMEOUT_MS))

--- a/Anamnesis/Services/GposeService.cs
+++ b/Anamnesis/Services/GposeService.cs
@@ -46,7 +46,7 @@ public class GposeService : ServiceBase<GposeService>
 	/// Checks if the user is in GPose photo mode by probing the game process' memory.
 	/// </summary>
 	/// <returns>True if the user is in GPose, false otherwise.</returns>
-	public static bool IsInGpose()
+	public static bool? IsInGpose()
 	{
 		if (s_isInGposeHook == null || !s_isInGposeHook.IsValid)
 			return false;
@@ -54,7 +54,7 @@ public class GposeService : ServiceBase<GposeService>
 		bool? result = null;
 		try
 		{
-			result = ControllerService.Instance.InvokeHook<bool>(s_isInGposeHook);
+			result = ControllerService.Instance.InvokeHook<bool>(s_isInGposeHook, timeoutMs: 250);
 			if (result == null)
 			{
 				Log.Warning("Gpose check hook did not return a result.");
@@ -65,7 +65,7 @@ public class GposeService : ServiceBase<GposeService>
 			Log.Verbose($"Failed to invoke 'IsGpose' hook.");
 		}
 
-		return result ?? false;
+		return result;
 	}
 
 	/// <inheritdoc/>
@@ -84,11 +84,11 @@ public class GposeService : ServiceBase<GposeService>
 		{
 			try
 			{
-				bool newGpose = IsInGpose();
-				if (newGpose != this.IsGpose)
+				bool? newGpose = IsInGpose();
+				if (newGpose.HasValue && newGpose != this.IsGpose)
 				{
-					this.IsGpose = newGpose;
-					GposeStateChanged?.Invoke(newGpose);
+					this.IsGpose = newGpose.Value;
+					GposeStateChanged?.Invoke(newGpose.Value);
 				}
 
 				await Task.Delay(TASK_DELAY_MS, cancellationToken);

--- a/Anamnesis/Services/MemoryService.cs
+++ b/Anamnesis/Services/MemoryService.cs
@@ -11,6 +11,7 @@ using Anamnesis.GUI.Windows;
 using Anamnesis.Keyboard;
 using Anamnesis.Services;
 using PropertyChanged;
+using RemoteController.Memory;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -27,7 +28,7 @@ using static Anamnesis.Memory.NativeFunctions;
 /// A service that handles memory operations on the game process.
 /// </summary>
 [AddINotifyPropertyChangedInterface]
-public partial class MemoryService : ServiceBase<MemoryService>
+public partial class MemoryService : ServiceBase<MemoryService>, IProcessMemoryReader
 {
 	/// <summary>
 	/// The maximum number of attempts to read from memory before failing.
@@ -115,6 +116,9 @@ public partial class MemoryService : ServiceBase<MemoryService>
 		}
 	}
 
+	/// <inheritdoc/>
+	bool IProcessMemoryReader.IsProcessAlive => IsProcessAlive;
+
 	/// <summary>
 	/// Reads a pointer from the specified memory address.
 	/// </summary>
@@ -143,7 +147,7 @@ public partial class MemoryService : ServiceBase<MemoryService>
 	/// <param name="address">The memory address to read the value from.</param>
 	/// <returns>The value read from the specified memory address, or null if the read fails.</returns>
 	/// <exception cref="Exception">Thrown if the specified memory address is invalid.</exception>
-	public static T? Read<T>(UIntPtr address)
+	public static T Read<T>(UIntPtr address)
 				where T : struct
 	{
 		unsafe
@@ -558,6 +562,54 @@ public partial class MemoryService : ServiceBase<MemoryService>
 	}
 
 	/// <inheritdoc/>
+	IntPtr IProcessMemoryReader.ReadPtr(IntPtr address) => ReadPtr(address);
+
+	/// <inheritdoc/>
+	T IProcessMemoryReader.Read<T>(IntPtr address) => Read<T>(address);
+
+	/// <inheritdoc/>
+	T IProcessMemoryReader.Read<T>(UIntPtr address) => Read<T>(address);
+
+	/// <inheritdoc/>
+	object IProcessMemoryReader.Read(IntPtr address, Type type) => Read(address, type);
+
+	/// <inheritdoc/>
+	bool IProcessMemoryReader.Read(UIntPtr address, byte[] buffer, UIntPtr size) => Read(address, buffer, size);
+
+	/// <inheritdoc/>
+	bool IProcessMemoryReader.Read(IntPtr address, byte[] buffer, int size) => Read(address, buffer, size);
+
+	/// <inheritdoc/>
+	bool IProcessMemoryReader.Read(IntPtr address, Span<byte> buffer) => Read(address, buffer);
+
+	/// <inheritdoc/>
+	byte IProcessMemoryReader.ReadByte(nint address, int offset) => ReadByte(address, offset);
+
+	/// <inheritdoc/>
+	short IProcessMemoryReader.ReadInt16(nint address, int offset) => ReadInt16(address, offset);
+
+	/// <inheritdoc/>
+	int IProcessMemoryReader.ReadInt32(nint address, int offset) => ReadInt32(address, offset);
+
+	/// <inheritdoc/>
+	long IProcessMemoryReader.ReadInt64(nint address, int offset) => ReadInt64(address, offset);
+
+	/// <inheritdoc/>
+	bool IProcessMemoryReader.Write(IntPtr address, byte[] buffer) => Write(address, buffer);
+
+	/// <inheritdoc/>
+	bool IProcessMemoryReader.Write(IntPtr address, Span<byte> buffer) => Write(address, buffer);
+
+	/// <inheritdoc/>
+	bool IProcessMemoryReader.Write<T>(IntPtr address, T value) => Write(address, value);
+
+	/// <inheritdoc/>
+	bool IProcessMemoryReader.Write(IntPtr address, object value) => Write(address, value);
+
+	/// <inheritdoc/>
+	bool IProcessMemoryReader.Write(IntPtr address, object value, Type type) => Write(address, value, type);
+
+	/// <inheritdoc/>
 	public override async Task Initialize()
 	{
 		await base.Initialize();
@@ -624,7 +676,7 @@ public partial class MemoryService : ServiceBase<MemoryService>
 			this.modules.Add(module.ModuleName, module.BaseAddress);
 		}
 
-		Scanner = new SignatureScanner(process.MainModule);
+		Scanner = new SignatureScanner(process.MainModule, this);
 	}
 
 	/// <summary>

--- a/Anamnesis/Services/PinnedActor.cs
+++ b/Anamnesis/Services/PinnedActor.cs
@@ -254,7 +254,7 @@ public class PinnedActor : INotifyPropertyChanged, IDisposable
 			this.Memory?.Do(a => a.PropertyChanged -= this.OnViewModelPropertyChanged);
 
 			ObjectHandle<GameObjectMemory>? newHandle = null;
-			bool isGPose = GposeService.IsInGpose();
+			bool? isGpose = GposeService.IsInGpose();
 
 			var actorHandles = ActorService.Instance.ObjectTable.GetAll();
 
@@ -279,7 +279,7 @@ public class PinnedActor : INotifyPropertyChanged, IDisposable
 					if (a.IsHidden)
 						return false;
 
-					if (a.IsGPoseActor != isGPose)
+					if (!isGpose.HasValue || a.IsGPoseActor != isGpose.Value)
 						return false;
 
 					return true;
@@ -309,7 +309,7 @@ public class PinnedActor : INotifyPropertyChanged, IDisposable
 						if (a.IsHidden)
 							return false;
 
-						if (a.IsGPoseActor != isGPose)
+						if (!isGpose.HasValue || a.IsGPoseActor != isGpose.Value)
 							return false;
 
 						// Is this actor memory already pinned to a different pin?
@@ -449,8 +449,9 @@ public class PinnedActor : INotifyPropertyChanged, IDisposable
 
 	private void OnRetargetedActor()
 	{
+		var isGpose = GposeService.IsInGpose();
 		// If we need to apply the appearance thanks to a GPose boundary changes?
-		if (SettingsService.Current.ReapplyAppearance || GposeService.IsInGpose())
+		if (SettingsService.Current.ReapplyAppearance || isGpose == true)
 		{
 			this.RestoreCharacterBackup(BackupModes.Gpose);
 

--- a/Anamnesis/Services/TargetService.cs
+++ b/Anamnesis/Services/TargetService.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using XivToolsWpf;
+using static RemoteController.Interop.Delegates.GameMain;
 
 /// <summary>
 /// A service that manages the selection and pinning of actors in the application.
@@ -436,9 +437,8 @@ public class TargetService : ServiceBase<TargetService>
 		{
 			try
 			{
-				bool isGpose = GposeService.IsInGpose();
-
 				var actorHandles = ActorService.Instance.ObjectTable.GetAll();
+				bool? isGpose = GposeService.IsInGpose();
 
 				// We want the first non-hidden actor with a name in the same mode as the game
 				foreach (var handle in actorHandles)
@@ -457,7 +457,7 @@ public class TargetService : ServiceBase<TargetService>
 						if (string.IsNullOrEmpty(a.Name))
 							return false;
 
-						if (a.IsGPoseActor != isGpose)
+						if (!isGpose.HasValue || a.IsGPoseActor != isGpose.Value)
 							return false;
 
 						return true;

--- a/Anamnesis/Tabs/DeveloperTab.xaml
+++ b/Anamnesis/Tabs/DeveloperTab.xaml
@@ -47,6 +47,24 @@
 						Style="{StaticResource TransparentButton}"
 						Padding="6,3"/>
 
+				<Button Content="Test framework task"
+						Click="OnFrameworkTask"
+						Height="32"
+						Style="{StaticResource TransparentButton}"
+						Padding="6,3"/>
+
+				<Button Content="Test framework task (Delayed)"
+						Click="OnFrameworkTaskDelayed"
+						Height="32"
+						Style="{StaticResource TransparentButton}"
+						Padding="6,3"/>
+
+				<Button Content="Test framework task (Cond)"
+						Click="OnFrameworkTaskCond"
+						Height="32"
+						Style="{StaticResource TransparentButton}"
+						Padding="6,3"/>
+
 			</StackPanel>
 		</GroupBox>
 

--- a/Anamnesis/Tabs/DeveloperTab.xaml.cs
+++ b/Anamnesis/Tabs/DeveloperTab.xaml.cs
@@ -98,7 +98,7 @@ public partial class DeveloperTab : UserControl
 
 		actorHandle.Do(async a =>
 		{
-			bool result = GposeService.IsInGpose();
+			bool? result = GposeService.IsInGpose();
 			await Dispatch.MainThread();
 			await GenericDialog.ShowAsync($"IsInGpose: {result}", "Hook Invocation", MessageBoxButton.OK);
 		});

--- a/Anamnesis/Tabs/DeveloperTab.xaml.cs
+++ b/Anamnesis/Tabs/DeveloperTab.xaml.cs
@@ -133,7 +133,7 @@ public partial class DeveloperTab : UserControl
 				counter++;
 				return counter >= targetTicks;
 			},
-			() =>
+			action: () =>
 			{
 				Log.Information("Framework Conditional Task Executed");
 			});

--- a/Anamnesis/Tabs/DeveloperTab.xaml.cs
+++ b/Anamnesis/Tabs/DeveloperTab.xaml.cs
@@ -104,6 +104,41 @@ public partial class DeveloperTab : UserControl
 		});
 	}
 
+	private void OnFrameworkTask(object sender, RoutedEventArgs e)
+	{
+		ControllerService.Instance.Framework.RunOnTick(() =>
+		{
+			Log.Information("Framework Task Executed");
+		});
+	}
+
+	private async void OnFrameworkTaskDelayed(object sender, RoutedEventArgs e)
+	{
+		TimeSpan delay = TimeSpan.FromSeconds(5);
+
+		await ControllerService.Instance.Framework.RunOnTick(delay, () =>
+		{
+			Log.Information("Framework Delayed Task Executed");
+		});
+	}
+
+	private void OnFrameworkTaskCond(object sender, RoutedEventArgs e)
+	{
+		var counter = 0;
+		var targetTicks = 30;
+
+		ControllerService.Instance.Framework.RunOnTickUntil(
+			() =>
+			{
+				counter++;
+				return counter >= targetTicks;
+			},
+			() =>
+			{
+				Log.Information("Framework Conditional Task Executed");
+			});
+	}
+
 	private void OnCopyActorAddressClicked(object sender, RoutedEventArgs e)
 	{
 		var handle = TargetService.PlayerTargetHandle;

--- a/RemoteController.SourceGenerators/HookDelegateRegistryGenerator.cs
+++ b/RemoteController.SourceGenerators/HookDelegateRegistryGenerator.cs
@@ -453,8 +453,9 @@ public class HookDelegateRegistryGenerator : IIncrementalGenerator
 
 	private static string GetFieldName(DelegateInfo del)
 	{
+		var classPrefix = string.IsNullOrEmpty(del.ParentClassName) ? "" : $"{char.ToLowerInvariant(del.ParentClassName[0])}{del.ParentClassName.Substring(1)}";
 		var name = del.DelegateName;
-		return $"s_{char.ToLowerInvariant(name[0])}{name.Substring(1)}";
+		return $"s_{classPrefix}{name}";
 	}
 
 	private static string GetFullDelegateTypeName(DelegateInfo del)
@@ -466,12 +467,14 @@ public class HookDelegateRegistryGenerator : IIncrementalGenerator
 
 	private static string GetSetupMethodName(DelegateInfo del)
 	{
-		return $"Setup{del.DelegateName}";
+		var classPrefix = string.IsNullOrEmpty(del.ParentClassName) ? "" : $"{del.ParentClassName}";
+		return $"Setup{classPrefix}{del.DelegateName}";
 	}
 
 	private static string GetInvokeMethodName(DelegateInfo del)
 	{
-		return $"Invoke{del.DelegateName}Typed";
+		var classPrefix = string.IsNullOrEmpty(del.ParentClassName) ? "" : $"{del.ParentClassName}";
+		return $"Invoke{classPrefix}{del.DelegateName}Typed";
 	}
 
 	private sealed class DelegateInfo(

--- a/RemoteController.SourceGenerators/HookDelegateRegistryGenerator.cs
+++ b/RemoteController.SourceGenerators/HookDelegateRegistryGenerator.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
-using System;
 using System.Collections.Immutable;
 using System.Text;
 
@@ -164,6 +163,7 @@ public class HookDelegateRegistryGenerator : IIncrementalGenerator
 			using Reloaded.Hooks;
 			using RemoteController.Interop.Delegates;
 			using RemoteController.IPC;
+			using RemoteController.Memory;
 			using Serilog;
 			using System.Collections.Concurrent;
 			using System.Diagnostics.CodeAnalysis;
@@ -252,14 +252,15 @@ public class HookDelegateRegistryGenerator : IIncrementalGenerator
 				/// </summary>
 				/// <param name="delegateKey">The unique identifier of the delegate</param>
 				/// <param name="hookId">The unique hook identifier.</param>
+				/// <param name="address">The target address of the function hook.</param>
 				/// <param name="regData">The hook registration data.</param>
 				/// <param name="reloadedHooks">A reference to a ReloadedHooks instance.</param>
 				/// <returns>The created function hook/wrapper, or null on failure.</returns>
-				public static IFunctionHook? CreateHook(string delegateKey, uint hookId, HookRegistrationData regData, ReloadedHooks reloadedHooks)
+				public static IFunctionHook? CreateHook(string delegateKey, uint hookId, nint address, HookRegistrationData regData, ReloadedHooks reloadedHooks)
 				{
 					try
 					{
-						if (regData.Address == 0)
+						if (address == 0)
 							return null;
 
 						var delegateType = Type.GetType(delegateKey);
@@ -275,7 +276,7 @@ public class HookDelegateRegistryGenerator : IIncrementalGenerator
 							return null;
 						}
 
-						var hook = HookFactory.Create(delegateKey, hookId, regData, reloadedHooks);
+						var hook = HookFactory.Create(delegateKey, hookId, address, regData, reloadedHooks);
 						if (hook == null)
 							return null;
 

--- a/RemoteController/Controller.cs
+++ b/RemoteController/Controller.cs
@@ -621,16 +621,8 @@ public class Controller
 	{
 		try
 		{
-			if (s_outgoingEndpoint == null)
-				return;
-
 			Log.Information("Received goodbye message from host. Shutting down controller...");
-
-			var header = new MessageHeader(msgId, PayloadType.Ack, 0);
-			if (!s_outgoingEndpoint.Write(header, s_emptyPayload, IPC_TIMEOUT_MS))
-			{
-				Log.Error($"Failed to acknowledge goodbye message from host application.");
-			}
+			SendResponse(msgId, PayloadType.Ack);
 		}
 		finally
 		{

--- a/RemoteController/FrameworkDriver.cs
+++ b/RemoteController/FrameworkDriver.cs
@@ -1,0 +1,91 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace RemoteController;
+
+using Reloaded.Hooks;
+using Reloaded.Hooks.Definitions;
+using RemoteController.Interop.Delegates;
+using Serilog;
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// A wrapper of framework object from the target process
+/// that drives synchronization with the host application.
+/// </summary>
+[RequiresUnreferencedCode("This class is not trimming-safe")]
+[RequiresDynamicCode("This class requires dynamic code due to hook reflection")]
+public class FrameworkDriver : IDisposable
+{
+	private readonly IHook<Framework.Tick> tickHook;
+	private bool disposedValue = false;
+	private bool isSyncEnabled = false;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="FrameworkDriver"/> class.
+	/// </summary>
+	/// <param name="tickFuncAddr">
+	/// The target function address of the framework tick method to hook.
+	/// </param>
+	public FrameworkDriver(IntPtr tickFuncAddr)
+	{
+		this.tickHook = ReloadedHooks.Instance.CreateHook<Framework.Tick>(this.DetourTick, tickFuncAddr);
+		this.tickHook.Activate();
+	}
+
+	/// <summary>
+	/// Gets or sets a value indicating whether framework synchronization is enabled.
+	/// </summary>
+	/// <remarks>
+	/// When this property is set to true, the framework driver will attempt to
+	/// synchronize the framework state with the host application on each tick.
+	/// </remarks>
+	public bool IsSyncEnabled
+	{
+		get => Volatile.Read(ref this.isSyncEnabled);
+		set => Interlocked.Exchange(ref this.isSyncEnabled, value);
+	}
+
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		this.Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
+
+	private byte DetourTick(nint fPtr)
+	{
+		// FAST EXIT: If there's no pending work, run the original function directly
+		if (!this.isSyncEnabled)
+			return this.tickHook!.OriginalFunction(fPtr);
+
+		try
+		{
+			this.isSyncEnabled = Controller.SendFrameworkRequest();
+		}
+		catch (Exception ex)
+		{
+			Log.Error(ex, "Encountered error during framework sync.");
+			this.isSyncEnabled = false;
+		}
+
+		return this.tickHook!.OriginalFunction(fPtr);
+	}
+
+	private void Dispose(bool disposing)
+	{
+		if (!this.disposedValue)
+		{
+			if (disposing)
+			{
+				this.tickHook.Disable();
+				if (this.tickHook is IDisposable disposable)
+				{
+					disposable.Dispose();
+				}
+			}
+
+			this.disposedValue = true;
+		}
+	}
+}

--- a/RemoteController/HookUtils.cs
+++ b/RemoteController/HookUtils.cs
@@ -36,6 +36,11 @@ public static class HookUtils
 /// </remarks>
 public static class HookMessageId
 {
+	public const uint MAX_STANDARD_HOOK_ID = 0x00FFFFFF - SYSTEM_HOOK_COUNT - 1;
+
+	// Reserved hook identifiers for system hooks
+	public const uint SYSTEM_HOOK_COUNT = 1;
+	public const uint FRAMEWORK_SYSTEM_ID = MAX_STANDARD_HOOK_ID + 1;
 	public const uint MAX_HOOK_ID = 0x00FFFFFF;
 
 	/// <summary>

--- a/RemoteController/HookUtils.cs
+++ b/RemoteController/HookUtils.cs
@@ -36,12 +36,15 @@ public static class HookUtils
 /// </remarks>
 public static class HookMessageId
 {
-	public const uint MAX_STANDARD_HOOK_ID = 0x00FFFFFF - SYSTEM_HOOK_COUNT - 1;
-
-	// Reserved hook identifiers for system hooks
-	public const uint SYSTEM_HOOK_COUNT = 1;
-	public const uint FRAMEWORK_SYSTEM_ID = MAX_STANDARD_HOOK_ID + 1;
 	public const uint MAX_HOOK_ID = 0x00FFFFFF;
+
+	// Special hook identifiers
+	public const int SPECIAL_HOOK_COUNT = 2;
+	public const uint FRAMEWORK_SYSTEM_ID = MAX_HOOK_ID - 1;
+	public const uint BATCH_HOOK_ID = FRAMEWORK_SYSTEM_ID - 1;
+
+	// Maximum hook identifier for non-specialized hooks.
+	public const uint MAX_STANDARD_HOOK_ID = MAX_HOOK_ID - SPECIAL_HOOK_COUNT - 1;
 
 	/// <summary>
 	/// Combines the hook identifier and message sequence number into a single packed identifier.

--- a/RemoteController/HookUtils.cs
+++ b/RemoteController/HookUtils.cs
@@ -38,10 +38,11 @@ public static class HookMessageId
 {
 	public const uint MAX_HOOK_ID = 0x00FFFFFF;
 
-	// Special hook identifiers
-	public const int SPECIAL_HOOK_COUNT = 2;
+	// Special-case message identifiers
+	public const int SPECIAL_HOOK_COUNT = 3;
 	public const uint FRAMEWORK_SYSTEM_ID = MAX_HOOK_ID - 1;
 	public const uint BATCH_HOOK_ID = FRAMEWORK_SYSTEM_ID - 1;
+	public const uint GOODBYE_MESSAGE_ID = BATCH_HOOK_ID - 1;
 
 	// Maximum hook identifier for non-specialized hooks.
 	public const uint MAX_STANDARD_HOOK_ID = MAX_HOOK_ID - SPECIAL_HOOK_COUNT - 1;

--- a/RemoteController/IPC/UnmanagedPayloadTypes.cs
+++ b/RemoteController/IPC/UnmanagedPayloadTypes.cs
@@ -22,6 +22,15 @@ public unsafe struct HookRegistrationData
 	public HookBehavior HookBehavior;
 
 	/// <summary>
+	/// Gets or sets the hook identifier to register.
+	/// </summary>
+	/// <remarks>
+	/// This field is only meant to be set for system hooks, for which
+	/// hook identifiers are static and known at compile time.
+	/// </remarks>
+	public uint HookId;
+
+	/// <summary>
 	/// Retrieves the delegate key from the internal byte array
 	/// as a UTF-8 encoded string.
 	/// </summary>
@@ -53,4 +62,37 @@ public unsafe struct HookRegistrationData
 			Encoding.UTF8.GetBytes(key, new Span<byte>(ptr, MAX_KEY_LENGTH));
 		}
 	}
+}
+
+public enum FrameworkMessageType : byte
+{
+	Unknown = 0,
+
+	/// <summary>
+	/// Message payload indicating to the framework driver
+	/// to propagate the detour on the next tick.
+	/// </summary>
+	EnableTickSync = 1,
+
+	/// <summary>
+	/// Message payload indicating to the main application
+	/// that the framework's thread is paused and we can
+	/// safely perform operations that require thread safety.
+	/// </summary>
+	TickSyncRequest = 2,
+
+	/// <summary>
+	/// Message payload indicating to the framework driver
+	/// to resume normal operation.
+	/// </summary>
+	TickSyncResponse = 3,
+}
+
+/// <summary>
+/// A framework message payload structure.
+/// </summary>
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public struct FrameworkMessageData
+{
+	public FrameworkMessageType Type;
 }

--- a/RemoteController/IPC/UnmanagedPayloadTypes.cs
+++ b/RemoteController/IPC/UnmanagedPayloadTypes.cs
@@ -17,7 +17,6 @@ public unsafe struct HookRegistrationData
 
 	public int DelegateKeyLength;
 	public fixed byte DelegateKey[MAX_KEY_LENGTH];
-	public nint Address;
 	public HookType HookType;
 	public HookBehavior HookBehavior;
 

--- a/RemoteController/IPC/WorkPipeline.cs
+++ b/RemoteController/IPC/WorkPipeline.cs
@@ -1,0 +1,176 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace RemoteController.IPC;
+
+using Serilog;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+/// <summary>
+/// An interface for a queueable work item.
+/// Designed for use with <see cref="WorkPipeline"/>.
+/// </summary>
+public interface IWorkItem
+{
+	void Execute();
+	void Cleanup();
+}
+
+/// <summary>
+/// A base implementation of a work item with state.
+/// </summary>
+/// <typeparam name="TState">
+/// The state object that is passed to the work item's function.
+/// </typeparam>
+public unsafe sealed class WorkItem<TState> : IWorkItem
+{
+	private ObjectPool<WorkItem<TState>>? pool;
+	private delegate* managed<TState, void> logicPtr;
+	private TState state = default!;
+
+	/// <summary>
+	/// Configures the work item prior to enqueueing into the work pipeline.
+	/// </summary>
+	/// <param name="pool">
+	/// A reference to the object pool that this work item was retrieved from.
+	/// </param>
+	/// <param name="logicPtr">
+	/// A pointer to the logic function for this work item.
+	/// </param>
+	/// <param name="state">
+	/// A state object that will be passed to the work item's function.
+	/// </param>
+	public void Initialize(
+		ObjectPool<WorkItem<TState>> pool,
+		delegate* managed<TState, void> logicPtr,
+		TState state)
+	{
+		this.pool = pool;
+		this.logicPtr = logicPtr;
+		this.state = state;
+	}
+
+	/// <summary>
+	/// Executes the work item's logic function.
+	/// </summary>
+	/// <remarks>
+	/// Manual invocation of this method is not desired.
+	/// Use <see cref="WorkPipeline"/> to manage work item execution.
+	/// </remarks>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Execute()
+	{
+#if DEBUG
+    if (this.logicPtr == null)
+        throw new InvalidOperationException("Work item logic pointer is null. Was Cleanup() called?");
+#endif
+
+		this.logicPtr(this.state);
+	}
+
+	/// <summary>
+	/// Cleans up the work item after execution and returns it to the pool.
+	/// </summary>
+	/// <remarks>
+	/// Manual invocation of this method is not desired.
+	/// Use <see cref="WorkPipeline"/> to manage work item lifetimes.
+	/// </remarks>
+	public void Cleanup()
+	{
+		this.logicPtr = null;
+		this.state = default!;
+		this.pool?.Return(this);
+	}
+}
+
+/// <summary>
+/// A pipeline for processing work items asynchronously with a pool of worker tasks.
+/// </summary>
+public sealed class WorkPipeline : IDisposable
+{
+	private readonly Channel<IWorkItem> channel;
+	private readonly ChannelWriter<IWorkItem> writer;
+	private readonly Task[] workers;
+	private readonly CancellationTokenSource cts = new();
+	private bool isDisposed = false;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="WorkPipeline"/> class.
+	/// </summary>
+	/// <param name="workers">
+	/// The number of worker tasks to spawn for processing work items.
+	/// </param>
+	public WorkPipeline(int workers = 2)
+	{
+		this.channel = Channel.CreateUnbounded<IWorkItem>(new UnboundedChannelOptions
+		{
+			SingleReader = workers == 1,
+			SingleWriter = false,
+			AllowSynchronousContinuations = false,
+		});
+		this.writer = this.channel.Writer;
+
+		this.workers = new Task[workers];
+		for (int i = 0; i < workers; i++)
+		{
+			this.workers[i] = Task.Factory.StartNew(this.ProcessLoop, TaskCreationOptions.LongRunning);
+		}
+	}
+
+	/// <summary>
+	/// Enqueues a work item for processing by the pipeline.
+	/// </summary>
+	/// <param name="work">
+	/// The work item to enqueue.
+	/// </param>
+	public void Enqueue(IWorkItem work) => this.writer.TryWrite(work);
+
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		this.Dispose(true);
+		GC.SuppressFinalize(this);
+	}
+
+	private async Task ProcessLoop()
+	{
+		var reader = this.channel.Reader;
+		while (await reader.WaitToReadAsync(this.cts.Token))
+		{
+			while (reader.TryRead(out var work))
+			{
+				try
+				{
+					work.Execute();
+				}
+				catch (Exception ex)
+				{
+					Log.Error(ex, "Work execution failed");
+				}
+				finally
+				{
+					work.Cleanup();
+				}
+			}
+		}
+	}
+
+	private void Dispose(bool disposing)
+	{
+		if (this.isDisposed)
+			return;
+
+		if (disposing)
+		{
+			this.cts.Cancel();
+			this.writer.TryComplete();
+			Task.WaitAll(this.workers);
+			this.cts.Dispose();
+		}
+
+		this.isDisposed = true;
+	}
+}

--- a/RemoteController/Interop/FunctionBindAttribute.cs
+++ b/RemoteController/Interop/FunctionBindAttribute.cs
@@ -6,29 +6,6 @@ namespace RemoteController.Interop;
 using System;
 
 /// <summary>
-/// An enum that specifies the invocation context of a function hook.
-/// Applicable only to <see cref="HookType.Wrapper"/> hooks.
-/// </summary>
-/// <remarks>
-/// <see cref="HookType.Interceptor"/> function hooks are always invoked
-/// synchronously within the existing call flow of the original function.
-/// </remarks>
-public enum HookInvokeContext
-{
-	/// <summary>
-	/// Invoke the function hook at the beginning of a framework
-	/// thread frame.
-	/// </summary>
-	FrameworkThread,
-
-	/// <summary>
-	/// Invoke the function hook asynchronously, detached from
-	/// the framework thread.
-	/// </summary>
-	Detached,
-}
-
-/// <summary>
 /// An enum that specifies the invocation behavior of a function hook.
 /// </summary>
 public enum HookBehavior
@@ -63,6 +40,12 @@ public enum HookType
 	/// <see cref="HookBehavior"/> for all available hook behavior options.
 	/// </summary>
 	Interceptor,
+
+	/// <summary>
+	/// A special interceptor hook type designed for system-level functions
+	/// that usually requires specific handling.
+	/// </summary>
+	System,
 }
 
 /// <summary>
@@ -72,7 +55,7 @@ public enum HookType
 /// <param name="signature">The memory signature of the function to hook.</param>
 /// <param name="offset">An optional offset to apply after signature resolution.</param>
 [AttributeUsage(AttributeTargets.Delegate, AllowMultiple = false)]
-public sealed class FunctionBindAttribute(string signature, int offset = 0, HookInvokeContext invokeCtx = HookInvokeContext.Detached) : Attribute
+public sealed class FunctionBindAttribute(string signature, int offset = 0) : Attribute
 {
 	/// <summary>
 	/// Gets the memory signature of the function to hook.
@@ -83,13 +66,4 @@ public sealed class FunctionBindAttribute(string signature, int offset = 0, Hook
 	/// Gets the offset to apply after signature resolution.
 	/// </summary>
 	public int Offset { get; } = offset;
-
-	/// <summary>
-	/// Gets the invocation context for this function hook.
-	/// </summary>
-	/// <remarks>
-	/// See <see cref="HookInvokeContext"/> for more information
-	/// on all available hook invocation contexts.
-	/// </remarks>
-	public HookInvokeContext InvokeContext { get; } = invokeCtx;
 }

--- a/RemoteController/Interop/FunctionBindAttribute.cs
+++ b/RemoteController/Interop/FunctionBindAttribute.cs
@@ -6,6 +6,22 @@ namespace RemoteController.Interop;
 using System;
 
 /// <summary>
+/// An enum that specifies the dispatch mode for function wrappers.
+/// </summary>
+public enum DispatchMode : byte
+{
+	/// <summary>
+	/// Executes the wrapper immediately as a detached thread call.
+	/// </summary>
+	Immediate = 0,
+
+	/// <summary>
+	/// Executes the wrapper on the next framework tick.
+	/// </summary>
+	FrameworkTick = 1,
+}
+
+/// <summary>
 /// An enum that specifies the invocation behavior of a function hook.
 /// </summary>
 public enum HookBehavior

--- a/RemoteController/Interop/FunctionBindAttribute.cs
+++ b/RemoteController/Interop/FunctionBindAttribute.cs
@@ -42,6 +42,9 @@ public enum HookBehavior
 	Replace,
 }
 
+/// <summary>
+/// An enum that specifies the type of function hook to create.
+/// </summary>
 public enum HookType
 {
 	/// <summary>
@@ -65,13 +68,37 @@ public enum HookType
 }
 
 /// <summary>
+/// An enum that specifies the strategy for resolving memory signatures.
+/// </summary>
+public enum SigResolveStrategy
+{
+	/// <summary>
+	/// Resolves the signature by scanning the module's .text section for a matching byte pattern.
+	/// </summary>
+	TextScan,
+
+	/// <summary>
+	/// Resolves the signature as a static address, with an optional offset.
+	/// </summary>
+	StaticAddress,
+
+	/// <summary>
+	/// Resolves the signature as a vtable entry, with an optional offset.
+	/// </summary>
+	VTableLookup,
+}
+
+/// <summary>
 /// Initializes a new instance of the <see cref="FunctionBindAttribute"/> class.
 /// </summary>
 /// <param name="hookType">The type of hook to create.</param>
 /// <param name="signature">The memory signature of the function to hook.</param>
 /// <param name="offset">An optional offset to apply after signature resolution.</param>
 [AttributeUsage(AttributeTargets.Delegate, AllowMultiple = false)]
-public sealed class FunctionBindAttribute(string signature, int offset = 0) : Attribute
+public sealed class FunctionBindAttribute(
+	string signature,
+	int offset = 0,
+	SigResolveStrategy strategy = SigResolveStrategy.TextScan) : Attribute
 {
 	/// <summary>
 	/// Gets the memory signature of the function to hook.
@@ -82,4 +109,10 @@ public sealed class FunctionBindAttribute(string signature, int offset = 0) : At
 	/// Gets the offset to apply after signature resolution.
 	/// </summary>
 	public int Offset { get; } = offset;
+
+	/// <summary>
+	/// Gets the resolution strategy for the specified signature.
+	/// The default is <see cref="SigResolveStrategy.TextScan"/>.
+	/// </summary>
+	public SigResolveStrategy Strategy { get; } = strategy;
 }

--- a/RemoteController/Interop/FunctionHooks.cs
+++ b/RemoteController/Interop/FunctionHooks.cs
@@ -87,6 +87,10 @@ internal sealed class FunctionHook<TDelegate>(uint id, string delegateKey, HookB
 		if (disposing)
 		{
 			this.hook.Disable();
+			if (this.hook is IDisposable disposable)
+			{
+				disposable.Dispose();
+			}
 		}
 		this.isDisposed = true;
 	}

--- a/RemoteController/Interop/HookDelegates.cs
+++ b/RemoteController/Interop/HookDelegates.cs
@@ -31,6 +31,21 @@ public static class Framework
 	public delegate void RenderGraphics(long a1);
 }
 
+public static class GameObject
+{
+	[FunctionBind("0F B6 81 ?? ?? ?? ?? 84 C0 78 2F")]
+	[UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+	public delegate byte EnableDraw(nint objPtr);
+
+	[FunctionBind("40 53 48 83 EC 20 80 B9 ?? ?? ?? ?? ?? 48 8B D9 7D 1F")]
+	[UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+	public delegate long DisableDraw(nint objPtr);
+
+	[FunctionBind("E8 ?? ?? ?? ?? 84 C0 74 ?? 48 8B 17 45 33 C9")]
+	[UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+	public delegate byte IsReadyToDraw(nint objPtr);
+}
+
 public static class GameMain
 {
 	[FunctionBind("E8 ?? ?? ?? ?? 83 7F ?? ?? 4C 8D 3D")]

--- a/RemoteController/Interop/HookDelegates.cs
+++ b/RemoteController/Interop/HookDelegates.cs
@@ -22,6 +22,10 @@ public static class Character
 
 public static class Framework
 {
+	[FunctionBind("48 8D 05 ?? ?? ?? ?? 66 C7 41 ?? ?? ?? 48 89 01 48 8B F1", offset: 0x20)]
+	[UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+	public delegate byte Tick(nint fPtr);
+
 	[FunctionBind("40 53 55 57 41 55 48 83 EC ?? ?? 48 ?? ?? ?? ?? ?? ?? ?? 48")]
 	[UnmanagedFunctionPointer(CallingConvention.StdCall)]
 	public delegate void RenderGraphics(long a1);

--- a/RemoteController/Interop/HookDelegates.cs
+++ b/RemoteController/Interop/HookDelegates.cs
@@ -30,28 +30,13 @@ public static class Character
 
 public static class Framework
 {
-	[FunctionBind("48 8D 05 ?? ?? ?? ?? 66 C7 41 ?? ?? ?? 48 89 01 48 8B F1", offset: 0x20)]
+	[FunctionBind("48 8D 05 ?? ?? ?? ?? 66 C7 41 ?? ?? ?? 48 89 01 48 8B F1", 0x20, SigResolveStrategy.VTableLookup)]
 	[UnmanagedFunctionPointer(CallingConvention.ThisCall)]
 	public delegate byte Tick(nint fPtr);
 
 	[FunctionBind("40 53 55 57 41 55 48 83 EC ?? ?? 48 ?? ?? ?? ?? ?? ?? ?? 48")]
 	[UnmanagedFunctionPointer(CallingConvention.StdCall)]
 	public delegate void RenderGraphics(long a1);
-}
-
-public static class GameObject
-{
-	[FunctionBind("0F B6 81 ?? ?? ?? ?? 84 C0 78 2F")]
-	[UnmanagedFunctionPointer(CallingConvention.ThisCall)]
-	public delegate byte EnableDraw(nint objPtr);
-
-	[FunctionBind("40 53 48 83 EC 20 80 B9 ?? ?? ?? ?? ?? 48 8B D9 7D 1F")]
-	[UnmanagedFunctionPointer(CallingConvention.ThisCall)]
-	public delegate long DisableDraw(nint objPtr);
-
-	[FunctionBind("E8 ?? ?? ?? ?? 84 C0 74 ?? 48 8B 17 45 33 C9")]
-	[UnmanagedFunctionPointer(CallingConvention.ThisCall)]
-	public delegate byte IsReadyToDraw(nint objPtr);
 }
 
 public static class GameMain

--- a/RemoteController/Interop/HookDelegates.cs
+++ b/RemoteController/Interop/HookDelegates.cs
@@ -15,6 +15,14 @@ public static class Camera
 
 public static class Character
 {
+	[FunctionBind("40 53 48 83 EC 20 80 B9 ?? ?? ?? ?? ?? 48 8B D9 7D 6E")]
+	[UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+	public delegate long DisableDraw(nint objPtr);
+
+	[FunctionBind("E8 ?? ?? ?? ?? 48 8B 8B ?? ?? ?? ?? 48 85 C9 74 33 45 33 C0")]
+	[UnmanagedFunctionPointer(CallingConvention.ThisCall)]
+	public delegate byte EnableDraw(nint objPtr);
+
 	[FunctionBind("E8 ?? ?? ?? ?? 84 C0 8B CF")]
 	[UnmanagedFunctionPointer(CallingConvention.ThisCall)]
 	public delegate bool IsWanderer(nint charPtr);

--- a/RemoteController/Interop/HookRegistry.cs
+++ b/RemoteController/Interop/HookRegistry.cs
@@ -102,9 +102,16 @@ public sealed class HookRegistry
 			}
 
 			uint hookId = this.AllocateHookId();
+			nint address = Controller.SigResolver?.Resolve(delegateKey) ?? 0;
 			try
 			{
-				var registeredHook = HookDelegateRegistry.CreateHook(delegateKey, hookId, regData, s_reloadedHooks.Value);
+				if (address == 0)
+				{
+					Log.Error($"Failed to resolve address for delegate key: {delegateKey}");
+					return 0;
+				}
+
+				var registeredHook = HookDelegateRegistry.CreateHook(delegateKey, hookId, address, regData, s_reloadedHooks.Value);
 				if (registeredHook == null)
 				{
 					Log.Error($"Failed to create hook instance for: {delegateKey}");
@@ -114,7 +121,7 @@ public sealed class HookRegistry
 				this.activeHooks[hookId] = registeredHook;
 				this.keyToHookId[delegateKey] = hookId;
 
-				Log.Information($"Registered hook[ID: {hookId}, Key: {delegateKey}] at 0x{regData.Address:X}");
+				Log.Information($"Registered hook[ID: {hookId}, Key: {delegateKey}] at 0x{address:X}");
 				return hookId;
 			}
 			catch (Exception ex)

--- a/RemoteController/Interop/HookRegistry.cs
+++ b/RemoteController/Interop/HookRegistry.cs
@@ -205,7 +205,7 @@ public sealed class HookRegistry
 		{
 			uint candidate = this.nextHookID++;
 
-			if (this.nextHookID >= HookMessageId.MAX_HOOK_ID)
+			if (this.nextHookID >= HookMessageId.MAX_STANDARD_HOOK_ID)
 				this.nextHookID = 1; // Skip 0 (Reserved for invalid hooks)
 
 			if (!this.activeHooks.ContainsKey(candidate))

--- a/RemoteController/Memory/IProcessMemoryReader.cs
+++ b/RemoteController/Memory/IProcessMemoryReader.cs
@@ -1,0 +1,152 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace RemoteController.Memory;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+public interface IProcessMemoryReader
+{
+	/// <summary>
+	/// Gets a value indicating whether the process is still alive.
+	/// </summary>
+	bool IsProcessAlive { get; }
+
+	/// <summary>
+	/// Reads a value of type <typeparamref name="T"/> from the specified memory address.
+	/// </summary>
+	/// <typeparam name="T">The type of value to read. The type must be a struct.</typeparam>
+	/// <param name="address">The memory address to read the value from.</param>
+	/// <returns>The value read from the specified memory address.</returns>
+	/// <exception cref="Exception">Thrown if the address is invalid or the read operation fails after multiple attempts.</exception>
+	T Read<T>(IntPtr address) where T : struct;
+
+	/// <summary>
+	/// Reads a value of type <typeparamref name="T"/> from the specified memory address.
+	/// </summary>
+	/// <typeparam name="T">The type of value to read. Must be a struct.</typeparam>
+	/// <param name="address">The memory address to read the value from.</param>
+	/// <returns>The value read from the specified memory address, or null if the read fails.</returns>
+	/// <exception cref="Exception">Thrown if the specified memory address is invalid.</exception>
+	T Read<T>(UIntPtr address) where T : struct;
+
+	/// <summary>
+	/// Reads a value of the specified type from the given memory address.
+	/// </summary>
+	/// <param name="address">The memory address to read the value from.</param>
+	/// <param name="type">The type of value to read.</param>
+	/// <returns>The value read from the specified memory address.</returns>
+	/// <exception cref="Exception">Thrown if the address is invalid or the read operation fails after multiple attempts.</exception>
+	[RequiresDynamicCode("Marshalling requires dynamic code")]
+	object Read(IntPtr address, Type type);
+
+	/// <summary>
+	/// Reads memory from the specified address into the provided buffer.
+	/// </summary>
+	/// <param name="address">The address to read from.</param>
+	/// <param name="buffer">The buffer to store the read data.</param>
+	/// <param name="size">The size of the data to read.</param>
+	/// <returns>True if the read operation was successful; otherwise, False.</returns>
+	bool Read(UIntPtr address, byte[] buffer, UIntPtr size);
+
+	/// <summary>
+	/// Reads memory from the specified address into the provided buffer.
+	/// </summary>
+	/// <param name="address">The address to read from.</param>
+	/// <param name="buffer">The buffer to store the read data.</param>
+	/// <param name="size">The size of the data to read. If less than or equal to 0, the buffer length is used.</param>
+	/// <returns>True if the read operation was successful; otherwise, False.</returns>
+	bool Read(IntPtr address, byte[] buffer, int size = -1);
+
+	/// <summary>
+	/// Reads memory from the specified address into the provided span buffer.
+	/// </summary>
+	/// <param name="address">The address to read from.</param>
+	/// <param name="buffer">The span buffer to store the read data.</param>
+	/// <returns>True if the read operation was successful; otherwise, False.</returns>
+	bool Read(IntPtr address, Span<byte> buffer);
+
+	/// <summary>
+	/// Reads a pointer from the specified memory address.
+	/// </summary>
+	/// <param name="address">The memory address to read the pointer from.</param>
+	/// <returns>The pointer read from the specified memory address.</returns>
+	IntPtr ReadPtr(IntPtr address);
+
+	/// <summary>
+	/// Reads a byte from the specified memory address with an optional offset.
+	/// </summary>
+	/// <param name="baseAddress">The base address to read from.</param>
+	/// <param name="offset">The offset from the base address.</param>
+	/// <returns>The byte value read from the specified address.</returns>
+	byte ReadByte(nint address, int offset = 0);
+
+	/// <summary>
+	/// Reads a 16-bit integer from the specified memory address with an optional offset.
+	/// </summary>
+	/// <param name="baseAddress">The base address to read from.</param>
+	/// <param name="offset">The offset from the base address.</param>
+	/// <returns>The 16-bit integer value read from the specified address.</returns>
+	short ReadInt16(nint address, int offset = 0);
+
+	/// <summary>
+	/// Reads a 32-bit integer from the specified memory address with an optional offset.
+	/// </summary>
+	/// <param name="baseAddress">The base address to read from.</param>
+	/// <param name="offset">The offset from the base address.</param>
+	/// <returns>The 32-bit integer value read from the specified address.</returns>
+	int ReadInt32(nint address, int offset = 0);
+
+	/// <summary>
+	/// Reads a 64-bit integer from the specified memory address with an optional offset.
+	/// </summary>
+	/// <param name="baseAddress">The base address to read from.</param>
+	/// <param name="offset">The offset from the base address.</param>
+	/// <returns>The 64-bit integer value read from the specified address.</returns>
+	long ReadInt64(nint address, int offset = 0);
+
+	/// <summary>
+	/// Writes a byte array to a specified memory address.
+	/// </summary>
+	/// <param name="address">The memory address to write to.</param>
+	/// <param name="buffer">The byte array to write.</param>
+	/// <returns>True if the write operation was successful, otherwise False.</returns>
+	bool Write(IntPtr address, byte[] buffer);
+
+	/// <summary>
+	/// Writes a span buffer to a specified memory address.
+	/// </summary>
+	/// <param name="address">The memory address to write to.</param>
+	/// <param name="buffer">The span buffer to write.</param>
+	/// <returns>True if the write operation was successful, otherwise False.</returns>
+	bool Write(IntPtr address, Span<byte> buffer);
+
+	/// <summary>
+	/// Writes a value of a specified type to a given memory address.
+	/// </summary>
+	/// <typeparam name="T">The type of the value to write. Must be a struct.</typeparam>
+	/// <param name="address">The memory address to write to.</param>
+	/// <param name="value">The value to write.</param>
+	/// <returns>True if the write operation was successful, otherwise False.</returns>
+	bool Write<T>(IntPtr address, T value) where T : struct;
+
+	/// <summary>
+	/// Writes an object value to a given memory address.
+	/// </summary>
+	/// <param name="address">The memory address to write to.</param>
+	/// <param name="value">The object value to write.</param>
+	/// <returns>True if the write operation was successful, otherwise False.</returns>
+	[RequiresDynamicCode("Marshalling requires dynamic code")]
+	bool Write(IntPtr address, object value);
+
+	/// <summary>
+	/// Writes an object value of a specified type to a given memory address.
+	/// </summary>
+	/// <param name="address">The memory address to write to.</param>
+	/// <param name="value">The object value to write.</param>
+	/// <param name="type">The type of the value to write.</param>
+	/// <returns>True if the write operation was successful, otherwise False.</returns>
+	[RequiresDynamicCode("Marshalling requires dynamic code")]
+	bool Write(IntPtr address, object value, Type type);
+}

--- a/RemoteController/Memory/InProcessMemoryReader.cs
+++ b/RemoteController/Memory/InProcessMemoryReader.cs
@@ -1,0 +1,112 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace RemoteController.Memory;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+/// <summary>
+/// An memory reader for direct read/write into the process' memory space.
+/// </summary>
+public sealed unsafe class InProcessMemoryReader : IProcessMemoryReader
+{
+	/// <inheritdoc/>
+	public bool IsProcessAlive => true; // Always alive since the controller is running in the same process.
+
+	/// <inheritdoc/>
+	public T Read<T>(IntPtr address) where T : struct
+	{
+		return Unsafe.Read<T>((void*)address);
+	}
+
+	/// <inheritdoc/>
+	public T Read<T>(UIntPtr address) where T : struct
+	{
+		return Unsafe.Read<T>((void*)address);
+	}
+
+	/// <inheritdoc/>
+	[RequiresDynamicCode("Marshalling requires dynamic code")]
+	public object Read(IntPtr address, Type type)
+	{
+		return Marshal.PtrToStructure(address, type)!;
+	}
+
+	/// <inheritdoc/>
+	public bool Read(UIntPtr address, byte[] buffer, UIntPtr size)
+	{
+		new Span<byte>((void*)address, (int)size).CopyTo(buffer);
+		return true;
+	}
+
+	/// <inheritdoc/>
+	public bool Read(IntPtr address, byte[] buffer, int size = -1)
+	{
+		if (size <= 0) size = buffer.Length;
+		new Span<byte>((void*)address, size).CopyTo(buffer);
+		return true;
+	}
+
+	/// <inheritdoc/>
+	public bool Read(IntPtr address, Span<byte> buffer)
+	{
+		new Span<byte>((void*)address, buffer.Length).CopyTo(buffer);
+		return true;
+	}
+
+	/// <inheritdoc/>
+	public IntPtr ReadPtr(IntPtr address) => *(IntPtr*)address;
+
+	/// <inheritdoc/>
+	public byte ReadByte(nint address, int offset = 0) => *(byte*)(address + offset);
+
+	/// <inheritdoc/>
+	public short ReadInt16(nint address, int offset = 0) => *(short*)(address + offset);
+
+	/// <inheritdoc/>
+	public int ReadInt32(nint address, int offset = 0) => *(int*)(address + offset);
+
+	/// <inheritdoc/>
+	public long ReadInt64(nint address, int offset = 0) => *(long*)(address + offset);
+
+	/// <inheritdoc/>
+	public bool Write(IntPtr address, byte[] buffer)
+	{
+		buffer.CopyTo(new Span<byte>((void*)address, buffer.Length));
+		return true;
+	}
+
+	/// <inheritdoc/>
+	public bool Write(IntPtr address, Span<byte> buffer)
+	{
+		buffer.CopyTo(new Span<byte>((void*)address, buffer.Length));
+		return true;
+	}
+
+	/// <inheritdoc/>
+	public bool Write<T>(IntPtr address, T value) where T : struct
+	{
+		Unsafe.Write((void*)address, value);
+		return true;
+	}
+
+	/// <inheritdoc/>
+	[RequiresDynamicCode("Marshalling requires dynamic code")]
+	public bool Write(IntPtr address, object value)
+	{
+		Marshal.StructureToPtr(value, address, false);
+		return true;
+	}
+
+	/// <inheritdoc/>
+	[RequiresDynamicCode("Marshalling requires dynamic code")]
+	public bool Write(IntPtr address, object value, Type type)
+	{
+		Marshal.StructureToPtr(value, address, false);
+		return true;
+	}
+}

--- a/RemoteController/Memory/MarshalUtils.cs
+++ b/RemoteController/Memory/MarshalUtils.cs
@@ -1,7 +1,7 @@
 ﻿// © Anamnesis.
 // Licensed under the MIT license.
 
-namespace RemoteController.IPC;
+namespace RemoteController.Memory;
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/RemoteController/Memory/SignatureResolver.cs
+++ b/RemoteController/Memory/SignatureResolver.cs
@@ -1,0 +1,160 @@
+﻿// © Anamnesis.
+// Licensed under the MIT license.
+
+namespace RemoteController.Memory;
+
+using RemoteController;
+using RemoteController.Interop;
+using Serilog;
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+
+/// <summary>
+/// An in-process memory signature resolver for the controller's function hook delegates.
+/// </summary>
+[RequiresUnreferencedCode("Reflection is used within the signature resolver")]
+public sealed class SignatureResolver
+{
+	private readonly SignatureScanner scanner;
+	private readonly IProcessMemoryReader memoryReader;
+	private readonly ConcurrentDictionary<string, nint> resolvedAddresses = new();
+	private readonly ConcurrentDictionary<string, Type> delegateTypeCache = new();
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SignatureResolver"/> class.
+	/// </summary>
+	/// <param name="scanner">The signature scanner to use for memory scanning.</param>
+	/// <param name="memoryReader">The memory reader for pointer dereferencing.</param>
+	public SignatureResolver(SignatureScanner scanner, IProcessMemoryReader memoryReader)
+	{
+		ArgumentNullException.ThrowIfNull(scanner, nameof(scanner));
+		ArgumentNullException.ThrowIfNull(memoryReader, nameof(memoryReader));
+
+		this.scanner = scanner;
+		this.memoryReader = memoryReader;
+		this.CacheDelegateTypes();
+	}
+
+	/// <summary>
+	/// Resolves the address for a delegate type identified by its key.
+	/// </summary>
+	/// <param name="delegateKey">The unique key identifying the delegate type.</param>
+	/// <returns>The resolved memory address, or <see cref="nint.Zero"/> if resolution fails.</returns>
+	public nint Resolve(string delegateKey)
+	{
+		if (this.resolvedAddresses.TryGetValue(delegateKey, out nint cached))
+			return cached;
+
+		if (!this.delegateTypeCache.TryGetValue(delegateKey, out Type? delegateType))
+		{
+			Log.Error($"Delegate type not found for key: {delegateKey}");
+			return nint.Zero;
+		}
+
+		var attr = delegateType.GetCustomAttribute<FunctionBindAttribute>();
+		if (attr == null)
+		{
+			Log.Error($"FunctionBindAttribute not found on delegate: {delegateKey}");
+			return nint.Zero;
+		}
+
+		return this.Resolve(delegateKey, attr);
+	}
+
+	/// <summary>
+	/// Resolves the address using the provided attribute configuration.
+	/// </summary>
+	/// <param name="delegateKey">The delegate key for caching purposes.</param>
+	/// <param name="attr">The function bind attribute containing resolution parameters.</param>
+	/// <returns>The resolved memory address, or <see cref="nint.Zero"/> if resolution fails.</returns>
+	public nint Resolve(string delegateKey, FunctionBindAttribute attr)
+	{
+		if (this.resolvedAddresses.TryGetValue(delegateKey, out nint cached))
+			return cached;
+
+		try
+		{
+			nint address = attr.Strategy switch
+			{
+				SigResolveStrategy.TextScan => this.ResolveTextScan(attr),
+				SigResolveStrategy.StaticAddress => this.ResolveStaticAddress(attr),
+				SigResolveStrategy.VTableLookup => this.ResolveVTableLookup(attr),
+				_ => throw new NotSupportedException($"Unknown resolution strategy: {attr.Strategy}"),
+			};
+
+			if (address != nint.Zero)
+			{
+				this.resolvedAddresses[delegateKey] = address;
+				Log.Debug($"Resolved [{delegateKey}] -> 0x{address:X} using {attr.Strategy}");
+			}
+
+			return address;
+		}
+		catch (Exception ex)
+		{
+			Log.Error(ex, $"Failed to resolve signature for {delegateKey}: {attr.Signature}");
+			return nint.Zero;
+		}
+	}
+
+	/// <summary>
+	/// Attempts to get a cached delegate type by its key.
+	/// </summary>
+	/// <param name="delegateKey">The delegate key.</param>
+	/// <param name="delegateType">The resolved delegate type, if found.</param>
+	/// <returns>True if the delegate type was found; otherwise, false.</returns>
+	public bool TryGetDelegateType(string delegateKey, out Type? delegateType)
+	{
+		return this.delegateTypeCache.TryGetValue(delegateKey, out delegateType);
+	}
+
+	/// <summary>
+	/// Clears all cached resolutions, forcing re-resolution on next access.
+	/// </summary>
+	public void ClearCache()
+	{
+		this.resolvedAddresses.Clear();
+	}
+
+	private nint ResolveTextScan(FunctionBindAttribute attr)
+	{
+		return this.scanner.ScanText(attr.Signature) + attr.Offset;
+	}
+
+	private nint ResolveStaticAddress(FunctionBindAttribute attr)
+	{
+		return this.scanner.GetStaticAddressFromSig(attr.Signature, attr.Offset);
+	}
+
+	private nint ResolveVTableLookup(FunctionBindAttribute attr)
+	{
+		// Get base vtable address
+		nint vtableBase = this.scanner.GetStaticAddressFromSig(attr.Signature);
+
+		// Offset to function in vtable
+		nint vtableSlot = vtableBase + attr.Offset;
+
+		// Dereference to get the actual function pointer
+		return this.memoryReader.ReadPtr(vtableSlot);
+	}
+
+	private void CacheDelegateTypes()
+	{
+		var assembly = typeof(SignatureResolver).Assembly;
+		var delegateTypes = assembly.GetTypes()
+			.Where(t => t.IsSubclassOf(typeof(Delegate)))
+			.Where(t => t.GetCustomAttribute<FunctionBindAttribute>() != null);
+
+		foreach (var type in delegateTypes)
+		{
+			string key = HookUtils.GetKey(type);
+			this.delegateTypeCache[key] = type;
+			Log.Verbose($"Cached delegate type: {key}");
+		}
+
+		Log.Debug($"Cached {this.delegateTypeCache.Count} delegate types for signature resolution.");
+	}
+}

--- a/RemoteController/RemoteController.csproj
+++ b/RemoteController/RemoteController.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
@@ -12,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Iced" Version="1.21.0" />
     <PackageReference Include="Reloaded.Hooks" Version="4.3.3" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
@@ -34,7 +34,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\RemoteController.SourceGenerators\RemoteController.SourceGenerators.csproj"
-                      OutputItemType="Analyzer" />
+    <ProjectReference Include="..\RemoteController.SourceGenerators\RemoteController.SourceGenerators.csproj" OutputItemType="Analyzer" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request builds on top of the new remote hooking system by allowing for work to be executed in sync with the framework tick. Wrapper-type function hooks can also be scheduled to be executed directly on the framework thread.

With the new system in place, the actor redrawing mechanism was reworked to use the game's internal game functions to perform the redraw. As a result, actor redraws are now deterministic and can be performed in GPose.

**Changelog:**
- New framework synchronization system using `FrameworkDriver` (remote controller) and `FrameworkService` (main application).
- Support for on-thread execution of wrapper function hooks on the framework thread.
- Ability to batch execute wrapper function hooks.
- Updated `GposeService` to keep the old gpose state if the wrapper hook invocation times out instead of setting it to an invalid state.
- Fixed naming collisions in hook delegate registry source generator.
- Fixed goodbye handshake sequence with remote controller.
- Fixed an issue in service manager that allowed for repeated shutdown calls for services that are already deinitialized.
- Optimizations and code cleanup on remote hook system.
- Signature scanner was moved to the remote controller project.
  - It is now possible to specify a memory process reader where the remote controller uses an in-process reader that does direct memory reads and writes, and the main application uses `MemoryService`, which uses the WinAPI methods for reading from/writing to external processes.
- Updated the injector's file deletion scheduling as `MoveFileEx` was creating duplicate entries in the registry.
- Bug fixes to new code in remote hook system.